### PR TITLE
Use semver ^5.1.0 as reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "dependencies": {},
   "devDependencies": {
+    "semver": "^5.1.0",
     "tape": "^3.0.0"
   },
   "scripts": {

--- a/test/cmp.js
+++ b/test/cmp.js
@@ -1,4 +1,5 @@
 var cmp = require('../');
+var semver = require('semver');
 var test = require('tape');
 
 var versions = [
@@ -15,15 +16,57 @@ var versions = [
 
 test('cmp', function (t) {
     t.plan(1);
-    t.deepEqual(versions.sort(cmp), [
-        '1.2.3',
-        '1.5.5',
-        '1.5.19',
-        '2.3.1',
-        '4.1.3',
-        '4.2.0',
-        '4.11.6',
-        '10.5.5',
-        '11.3.0'
-    ]);
+    t.deepEqual(versions.sort(cmp),
+                versions.sort(semver.compare));
+
 });
+
+test('cmp pre-release', function(t) {
+    t.plan(2);
+    t.deepEqual(versionsPre1.sort(cmp),
+                versionsPre1.sort(semver.compare));
+    t.deepEqual(versionsPre2.sort(cmp),
+                versionsPre2.sort(semver.compare));
+});
+
+var versionsPre1 = [
+    '1.2.3',
+    '1.2.3-alpha',
+    '1.0.0-x.7.z.92',
+    '1.0.0-alpha.1',
+    '1.0.0-alpha',
+    '4.11.6',
+    '4.2.0',
+    '1.5.19',
+    '1.5.5',
+    '4.1.3',
+    '2.3.1',
+    '10.5.5',
+    '11.3.0',
+    '1.0.0',
+    '1.0.0-rc.1',
+    '1.0.0-beta.11',
+    '1.0.0-beta',
+    '1.0.0-beta.2',
+    '1.0.0-alpha.beta',
+    '1.0.0-alpha.1',
+    '1.0.0-alpha',
+];
+
+var versionsPre2 = [
+  '1.2.3',
+  '1.2.3-alpha',
+  '1.0.0-x.7.z.92',
+  '1.0.0-alpha.1',
+  '1.0.0-alpha',
+  '4.11.6',
+  '11.3.0',
+  '1.0.0',
+  '1.0.0-rc.1',
+  '1.0.0-beta.11',
+  '1.0.0-beta',
+  '1.0.0-beta.2',
+  '1.0.0-alpha.beta',
+  '1.0.0-alpha.1',
+  '1.0.0-alpha',
+];


### PR DESCRIPTION
Tests against npm semver.

Issue with pre-releases (#1) isn't showing up
(on npm 3.6.0 and node v5.7.1). Introduces a 
dev dependency on semver.